### PR TITLE
Refatoração do Makefile para tratamento de erros e remoção do suporte ao macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,18 @@
 KIND_VERSION ?= 0.18.0
 GIROPOPS_SENHAS_VERSION ?= 1.0
 GIROPOPS_LOCUST_VERSION ?= 1.0
-
-# Definir o sistema operacional
-OS := $(shell uname -s)
+KUBECTL_VERSION ?= v1.26.3
+ISTIO_VERSION ?= 1.17.1
 
 # Tarefas principais
 .PHONY: all
 all: docker kind kubectl metallb kube-prometheus istio kiali argocd giropops-senhas giropops-locust 
 
-OS := $(shell uname -s)
-
-ifeq ($(OS),Linux)
-  DOCKER_COMMAND = "sudo curl -fsSL https://get.docker.com | bash"s
-  KIND_COMMAND = "curl -Lo ./kind https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind"
-  KUBECTL_COMMAND = "curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl"
-else ifeq ($(OS),Darwin)
-  DOCKER_COMMAND = brew install docker && brew install colima && colima start
-  KIND_COMMAND = brew install kind
-  KUBECTL_COMMAND = brew install kubectl
-else
-  $(error Unsupported operating system: $(OS))
-endif
+DOCKER_COMMAND = sudo curl -fsSL https://get.docker.com | bash
+KIND_COMMAND = "curl -Lo ./kind https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind"
+KUBECTL_COMMAND = "curl -LO https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/"
+ARGOCD_COMMAND = curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd && rm argocd-linux-amd64
+ISTIO_COMMAND = curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} TARGET_ARCH=x86_64 sh - && cd istio-${ISTIO_VERSION} && export PATH=$$PWD/bin:$$PATH && istioctl install --set profile=default -y
 
 # Instalação do Docker
 .PHONY: docker
@@ -36,16 +27,20 @@ docker:
 kind:
 	@echo "Instalando o Kind..."
 	@command -v kind >/dev/null 2>&1 || $(KIND_COMMAND)
-	@if [ -z "$$(kind get clusters | grep kind-linuxtips)" ]; then kind create cluster --name kind-linuxtips --config kind-config/kind-cluster-3-nodes.yaml; fi
+	@while ! command -v kind >/dev/null 2>&1; do \
+		sleep 1; \
+	done
 	@echo "Kind instalado com sucesso!"
+	@echo "Criando o cluster..."
+	@if [ -z "$$(kind get clusters | grep kind-linuxtips)" ]; then kind create cluster --name kind-linuxtips --config kind-config/kind-cluster-3-nodes.yaml; fi
+	@echo "Cluster criado com sucesso!"
 
 # Instalação do kubectl
 .PHONY: kubectl
 kubectl:
 	@echo "Instalando o kubectl..."
-	@command -v kubectl >/dev/null 2>&1 || ($(KUBECTL_COMMAND) && kubectl version)
+	@command -v kubectl >/dev/null 2>&1 || $(KUBECTL_COMMAND)
 	@echo "Kubectl instalado com sucesso!"
-
 
 # Login no ArgoCD
 .PHONY: argo_login
@@ -64,6 +59,12 @@ add_cluster:
 	$(eval PORT_ENDPOINT := $(shell kubectl get endpoints kubernetes -o jsonpath='{.subsets[0].ports[0].port}'))
 	$(eval IP_K8S_IP := $(shell kubectl cluster-info | awk '{print $$7}' | head -n 1 | sed 's/\x1b\[[0-9;]*m//g' | sed 's/https:\/\///g'))
 	@sed -i "s/https:\/\/$(IP_K8S_IP)/https:\/\/$(IP_K8S_API_ENDPOINT):6443/g" ~/.kube/config
+# Debug
+	@echo "IP_K8S_API_ENDPOINT: ${IP_K8S_API_ENDPOINT}"
+	@echo "CLUSTER: ${CLUSTER}"
+	@echo "PORT_ENDPOINT: ${PORT_ENDPOINT}"
+	@echo "IP_K8S_IP: ${IP_K8S_IP}"
+# End Debug
 	argocd cluster add --insecure -y $(CLUSTER)
 	@echo "Cluster adicionado com sucesso!"
 
@@ -72,18 +73,15 @@ add_cluster:
 argocd:
 	@echo "Instalando o ArgoCD e o Giropops-Senhas..."
 	if [ -z "$$(kubectl get namespace argocd)" ]; then kubectl create namespace argocd; fi
+	$(ARGOCD_COMMAND)
 	kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
-	curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
-	sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
-	rm argocd-linux-amd64
-	kubectl wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/name=argocd-server -n argocd
+	kubectl wait --for=condition=ready --timeout=10m pod -l app.kubernetes.io/name=argocd-server -n argocd
 	$(MAKE) argo_login
 	$(MAKE) add_cluster
 	ps -ef | grep -v "ps -ef" | grep kubectl | grep port-forward | grep argocd-server | awk '{print $$2}' | xargs kill
 	kubectl label namespace default istio-injection=enabled
 	kubectl label namespace argocd istio-injection=enabled
 	@echo "ArgoCD foi instalado com sucesso!"
-
 
 # Instalando o Giropops-Senhas
 .PHONY: giropops-senhas
@@ -95,7 +93,6 @@ giropops-senhas:
 	argocd app sync giropops-senhas
 	ps -ef | grep -v "ps -ef" | grep kubectl | grep port-forward | grep argocd-server | awk '{print $$2}' | xargs kill
 	@echo "Giropops-Senhas foi instalado com sucesso!"
-
 
 # Instalando o Giropops-Locust
 .PHONY: giropops-locust
@@ -112,7 +109,7 @@ giropops-locust:
 .PHONY: kube-prometheus
 kube-prometheus:
 	@echo "Instalando o Kube-Prometheus..."
-	git clone https://github.com/prometheus-operator/kube-prometheus
+	git clone https://github.com/prometheus-operator/kube-prometheus || true
 	cd kube-prometheus
 	kubectl create -f kube-prometheus/manifests/setup
 	until kubectl get servicemonitors; do sleep 1; done
@@ -128,22 +125,18 @@ kube-prometheus:
 metallb:
 	@echo "Instalando o MetalLB..."
 	kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
-	kubectl wait --for=condition=ready --timeout=300s pod -l app=metallb -n metallb-system
+	kubectl wait --for=condition=ready --timeout=10m pod -l app=metallb -n metallb-system
 	kubectl apply -f metallb-config/metallb-config.yaml
 	@echo "MetalLB foi instalado com sucesso!"
-
 
 # Instalando o Istio
 .PHONY: istio
 istio:
 	@echo "Instalando o Istio..."
-	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.17.1 TARGET_ARCH=x86_64 sh -
-	cd istio-1.17.1
-	export PATH=$$PWD/bin:$$PATH
-	istioctl install --set profile=default -y
+	$(ISTIO_COMMAND)
 	kubectl label namespace default istio-injection=enabled
 	kubectl wait --for=condition=ready --timeout=300s pod -l app=istiod -n istio-system
-	rm -rf istio-1.17.1
+	rm -rf istio-${ISTIO_VERSION}
 	@echo "Istio foi instalado com sucesso!"
 
 # Instalando o Kiali
@@ -151,7 +144,10 @@ istio:
 kiali: 
 	@echo "Instalando o Kiali..."
 	kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.17/samples/addons/kiali.yaml
-	kubectl wait --for=condition=ready --timeout=300s pod -l app=kiali -n istio-system
+	while true; do \
+		kubectl wait --for=condition=ready --timeout=10m pod -l app=kiali -n istio-system && break; \
+		sleep 5; \
+	done
 	kubectl apply -f istio-config/
 	kubectl rollout restart deployment kiali -n istio-system
 	@echo "Kiali foi instalado com sucesso!"
@@ -159,11 +155,17 @@ kiali:
 # Removendo o Kind e limpando tudo que foi instalado
 .PHONY: clean
 clean:
-	@echo "Removendo o Kind..."
-	kind delete cluster --name kind-linuxtips
-	@echo "Kind removido com sucesso!"
-ifeq ($(OS),Darwin)
-	@echo "Encerrando o Colima..."
-	@colima stop
-	@echo "Colima encerrado com sucesso!"
-endif
+	@echo "Desinstalando o Istio..."
+	istioctl x uninstall --purge || true
+	rm -rf istio-${ISTIO_VERSION} || true
+	@echo "Istio desinstalado com sucesso!"
+	@echo "Desinstalando o ArgoCD..."
+	rm -f argocd-linux-amd64 || true
+	sudo rm /usr/local/bin/argocd || true
+	sudo rm -rf /etc/argocd /var/lib/argocd || true
+	@echo "ArgoCD removido com sucesso!"
+	@echo "Removendo o cluster do Kind..."
+	kind delete cluster --name kind-linuxtips || true
+	@echo "Cluster removido com sucesso!"
+	@echo "Removendo diretórios kube-prometheus..."
+	@sudo rm -r kube-prometheus

--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,27 @@
 KIND_VERSION ?= 0.18.0
 GIROPOPS_SENHAS_VERSION ?= 1.0
 GIROPOPS_LOCUST_VERSION ?= 1.0
-KUBECTL_VERSION ?= v1.26.3
 ISTIO_VERSION ?= 1.17.1
+CHAOS_MESH_VERSION ?= v2.5.1
+KIALI_VERSION ?= 1.17
+METALLB_VERSION ?= v0.13.9
+KUBERNETES_DASHBOARD_VERSION ?= v2.7.0
 
 # Tarefas principais
 .PHONY: all
 all: docker kind kubectl metallb kube-prometheus istio kiali argocd giropops-senhas giropops-locust chaos-mesh kubernetes-dashboard
 
-DOCKER_COMMAND = sudo curl -fsSL https://get.docker.com | bash
-KIND_COMMAND = "curl -Lo ./kind https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64 && chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind"
-KUBECTL_COMMAND = "curl -LO https://storage.googleapis.com/kubernetes-release/release/$(KUBECTL_VERSION)/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/"
-ARGOCD_COMMAND = curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64 && sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd && rm argocd-linux-amd64
-ISTIO_COMMAND = curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} TARGET_ARCH=x86_64 sh - && cd istio-${ISTIO_VERSION} && export PATH=$$PWD/bin:$$PATH && istioctl install --set profile=default -y
-
 # Instalação do Docker
 .PHONY: docker
 docker:
 	@echo "Instalando o Docker..."
-	@command -v docker >/dev/null 2>&1 || $(DOCKER_COMMAND)
-	@echo "Docker instalado com sucesso!"
+	@command -v docker >/dev/null 2>&1 || sudo curl -fsSL https://get.docker.com | bash
 
 # Instalação do Kind
 .PHONY: kind
 kind:
 	@echo "Instalando o Kind..."
-	@command -v kind >/dev/null 2>&1 || $(KIND_COMMAND)
+	@comman -v kind >/dev/null 2>&1 || curl -Lo ./kind "https://kind.sigs.k8s.io/dl/v$(KIND_VERSION)/kind-linux-amd64" && chmod +x ./kind && sudo mv ./kind /usr/local/bin/
 	@while ! command -v kind >/dev/null 2>&1; do \
 		sleep 1; \
 	done
@@ -39,7 +35,7 @@ kind:
 .PHONY: kubectl
 kubectl:
 	@echo "Instalando o kubectl..."
-	@command -v kubectl >/dev/null 2>&1 || $(KUBECTL_COMMAND)
+	@command -v kubectl >/dev/null 2>&1 || (curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl && chmod +x ./kubectl && sudo mv ./kubectl /usr/local/bin/kubectl)
 	@echo "Kubectl instalado com sucesso!"
 
 # Login no ArgoCD
@@ -71,7 +67,7 @@ argocd:
 	curl -sSL -o argocd-linux-amd64 https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
 	sudo install -m 555 argocd-linux-amd64 /usr/local/bin/argocd
 	rm argocd-linux-amd64
-	kubectl wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/name=argocd-server -n argocd
+	kubectl wait --for=condition=ready --timeout=10m pod -l app.kubernetes.io/name=argocd-server -n argocd
 	$(MAKE) argo_login
 	$(MAKE) add_cluster
 	ps -ef | grep -v "ps -ef" | grep kubectl | grep port-forward | grep argocd-server | awk '{print $$2}' | xargs kill
@@ -110,7 +106,7 @@ kube-prometheus:
 	kubectl create -f kube-prometheus/manifests/setup
 	until kubectl get servicemonitors; do sleep 1; done
 	kubectl create -f kube-prometheus/manifests/
-	kubectl wait --for=condition=ready --timeout=300s pod -l app.kubernetes.io/part-of=kube-prometheus -n monitoring
+	kubectl wait --for=condition=ready --timeout=10m pod -l app.kubernetes.io/part-of=kube-prometheus -n monitoring
 	kubectl apply -f prometheus-config/
 	rm -rf kube-prometheus
 	kubectl label namespace monitoring istio-injection=enabled
@@ -120,7 +116,7 @@ kube-prometheus:
 .PHONY: metallb
 metallb:
 	@echo "Instalando o MetalLB..."
-	kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.9/config/manifests/metallb-native.yaml
+	kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/config/manifests/metallb-native.yaml
 	kubectl wait --for=condition=ready --timeout=10m pod -l app=metallb -n metallb-system
 	kubectl apply -f metallb-config/metallb-config.yaml
 	@echo "MetalLB foi instalado com sucesso!"
@@ -129,9 +125,11 @@ metallb:
 .PHONY: istio
 istio:
 	@echo "Instalando o Istio..."
-	$(ISTIO_COMMAND)
+	curl -L https://istio.io/downloadIstio | ISTIO_VERSION=${ISTIO_VERSION} TARGET_ARCH=x86_64 sh -
+	sleep 2
+	./istio-1.17.1/bin/istioctl install --set profile=default -y
 	kubectl label namespace default istio-injection=enabled
-	kubectl wait --for=condition=ready --timeout=300s pod -l app=istiod -n istio-system
+	kubectl wait --for=condition=ready --timeout=10m pod -l app=istiod -n istio-system
 	rm -rf istio-${ISTIO_VERSION}
 	@echo "Istio foi instalado com sucesso!"
 
@@ -139,11 +137,8 @@ istio:
 .PHONY: kiali
 kiali: 
 	@echo "Instalando o Kiali..."
-	kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.17/samples/addons/kiali.yaml
-	while true; do \
-		kubectl wait --for=condition=ready --timeout=10m pod -l app=kiali -n istio-system && break; \
-		sleep 5; \
-	done
+	kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-${KIALI_VERSION}/samples/addons/kiali.yaml
+	kubectl wait --for=condition=ready --timeout=10m pod -l app=kiali -n istio-system
 	kubectl apply -f istio-config/
 	kubectl rollout restart deployment kiali -n istio-system
 	@echo "Kiali foi instalado com sucesso!"
@@ -152,7 +147,7 @@ kiali:
 .PHONY: chaos-mesh
 chaos-mesh:
 	@echo "Instalando o Chaos Mesh Operator"
-	curl -fsSL https://mirrors.chaos-mesh.org/v2.5.1/install.sh | bash -s -- --local kind --name kind-linuxtips
+	curl -sSL https://mirrors.chaos-mesh.org/${CHAOS_MESH_VERSION}/install.sh | bash -s -- --local kind --name kind-linuxtips
 	sleep 3
 	@echo "Chaos Mesh instalado com sucesso!"
 
@@ -160,18 +155,18 @@ chaos-mesh:
 .PHONY: kubernetes-dashboard
 kubernetes-dashboard:
 	@echo "Instalando o Kubernetes Dashboard..."
-	kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
-	kubectl wait --for=condition=ready --timeout=300s pod -l k8s-app=kubernetes-dashboard -n kubernetes-dashboard
+	kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/${KUBERNETES_DASHBOARD_VERSION}/aio/deploy/recommended.yaml
+	kubectl wait --for=condition=ready --timeout=10m pod -l k8s-app=kubernetes-dashboard -n kubernetes-dashboard
 	kubectl apply -f dash-config/
 	@echo "Kubernetes Dashboard instalado com sucesso!"
-	@echo "Para criar o token de acesso ao Dashboard, execute o comando: make dashboard_token"
+	@echo "Para criar o token de acesso ao Dashboard, execute o comando: make dashboard-token"
 
 # Criando o token de acesso ao Kubernetes Dashboard
 .PHONY: dashboard-token
 dashboard-token:
 	@echo "Criando o token de acesso ao Kubernetes Dashboard..."
 	kubectl -n kubernetes-dashboard create token admin-user
-	kubectl wait --for=condition=ready --timeout=300s pod -l k8s-app=kubernetes-dashboard -n kubernetes-dashboard
+	kubectl wait --for=condition=ready --timeout=10m pod -l k8s-app=kubernetes-dashboard -n kubernetes-dashboard
 	@echo "Token criado com sucesso!"
 
 # Removendo o Kind e limpando tudo que foi instalado


### PR DESCRIPTION
# Comentários

Devido algumas falhas na implementação do Makefile para macOS, restaurei o original com pequenas alterações para tratamento de erros.

Sugestão: Para garantir a organização e evitar possíveis interferências no desenvolvimento do projeto, sugiro criar uma branch específica para o desenvolvimento e testes voltados para o macOS. 
Exemplo: https://github.com/Rapha-Borges/giropops-senhas/tree/macOS

# Alterações

Remoções:
- Validação do OS
- Condições exclusivas para macOS
- Comando `kubectl version` desnecessário

Adicionado:
- Variáveis para controle de versão do `kubectl` e `Istio`
- Variáveis para instalação do  `ArgoCD`e `Istio`
- Laço para validação da criação do cluster
- Parâmetro `|| true` no download do repositório `kube-prometheus`
- Tempo de 10 minutos para timeout na instalação do `MetalLB` `--timeout=10m` 
- Laço para validação do `Kiali`
- Instruções do `make clean` para desinstalar e remover diretórios do `Istio` e `ArgoCD`
- Instruções do `make clean` para remover o diretório `kube-prometheus`